### PR TITLE
FIx hotp_test.go

### DIFF
--- a/hotp_test.go
+++ b/hotp_test.go
@@ -47,7 +47,7 @@ func TestHOTP(t *testing.T) {
 	for index, code := range codes {
 		counter := uint64(index)
 		if !hotp.Verify(code, counter) {
-			t.Errorf("%s, %s, %s", index, code)
+			t.Errorf("%d, %s", index, code)
 			return
 		}
 	}


### PR DESCRIPTION
Hi,
    I find something wrong in hotp_test.go,  so  I fix it

```go
t.Errorf("%s, %s, %s", index, code)   =>  t.Errorf("%d, %s", index, code)
```